### PR TITLE
In addition to my last pull request

### DIFF
--- a/src/main/java/org/ghost4j/analyzer/InkAnalyzer.java
+++ b/src/main/java/org/ghost4j/analyzer/InkAnalyzer.java
@@ -149,7 +149,7 @@ public class InkAnalyzer extends AbstractRemoteAnalyzer implements Analyzer {
      * @throws ParseException
      */
     private double parseValue(String value) throws ParseException {
-    	return Double.parseDouble(value.trim());
+    	return Double.parseDouble(value.trim().replace(",","."));
     }
 
     @Override


### PR DESCRIPTION
With my las commit, everything was working fine in windows, but when I
try under Linux, I realized something :
Under Linux, ghostscript was sending back ink coverages values with
comma as separator (i'm in French LOCALE) , whereas it use point separator under windows.

It also explain the ClassCastException before my last commit -> the
Decimal formatter was expecting comma as separator.

So here is my solution.

Possible limitations -> passing a number formatted as "123,299.33" will rise an exception.
