### PR TITLE
Workaround to make ghost4j compatible with JDKs >= 1.8u242

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -230,6 +230,10 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>2.8.1</version>
+                <configuration>
+                    <stylesheet>maven</stylesheet>
+                    <additionalparam>-Xdoclint:none</additionalparam>
+                </configuration>
                 <executions>
                     <execution>
                         <phase>verify</phase>

--- a/src/main/java/gnu/cajo/invoke/Invoke.java
+++ b/src/main/java/gnu/cajo/invoke/Invoke.java
@@ -36,7 +36,7 @@ package gnu.cajo.invoke;
  * @version 1.0, 01-Nov-99  Initial release
  * @author John Catherino
  */
-public interface Invoke extends java.io.Serializable {
+public interface Invoke extends java.io.Serializable, java.rmi.Remote {
    /**
     * Used by other objects to pass data into this object, and receive
     * synchronous data responses from it, if any. The invocation may, or may


### PR DESCRIPTION
This is only a hacky workaround due to my limited knowledge of the codebase to satisfy the requirements of newer JDKs (see the hint in my commit messages).

I know there is a `RemoteInvoke` interface which correctly implements the required RMI `java.rmi.Remote` interface. Unfortunately a call to the `PdfConverter.convert()` method always picks the regular `Invoke` interface which then in turn fails with JDKs starting from version 1.8u242 because the RMI spec now requires interfaces which are used for RMI calls to implement `java.rmi.Remote`.

According to these release notes it seems that it previously worked by accident because this policy wasn't enforced before Java 1.8u242:
https://www.oracle.com/technetwork/java/javase/8u241-relnotes-5813177.html

I'd appreciate if any of the project maintainers could come up with a better solution which addresses the root cause of this issue.